### PR TITLE
Subresource Integrity

### DIFF
--- a/src/hanami-esbuild-plugin.ts
+++ b/src/hanami-esbuild-plugin.ts
@@ -9,21 +9,26 @@ import crypto from 'node:crypto';
 
 const URL_SEPARATOR = '/';
 
-interface HanamiEsbuildPluginOptions {
+export interface HanamiEsbuildPluginOptions {
   root: string;
   publicDir: string;
   destDir: string;
   manifestPath: string;
-  sriAlgorithm: string;
+  sriAlgorithms: Array<string>;
 }
 
-const defaults: Pick<HanamiEsbuildPluginOptions, 'root' | 'publicDir' | 'destDir' | 'manifestPath' | 'sriAlgorithm'> = {
+export const defaults: Pick<HanamiEsbuildPluginOptions, 'root' | 'publicDir' | 'destDir' | 'manifestPath' | 'sriAlgorithms'> = {
   root: '',
   publicDir: 'public',
   destDir: path.join('public', 'assets'),
   manifestPath: path.join('public', 'assets.json'),
-  sriAlgorithm: 'sha256',
+  sriAlgorithms: [],
 };
+
+interface Asset {
+  url: string;
+  sri?: Array<string>;
+}
 
 const hanamiEsbuild = (options: HanamiEsbuildPluginOptions = { ...defaults }): Plugin => {
   return {
@@ -37,7 +42,7 @@ const hanamiEsbuild = (options: HanamiEsbuildPluginOptions = { ...defaults }): P
 
       build.onEnd(async (result: BuildResult) => {
         const outputs = result.metafile?.outputs;
-        const assetsManifest: Record<string, Record<string, string>> = {};
+        const assetsManifest: Record<string, Asset> = {};
 
         const calulateSourceUrl = (str: string): string => {
           return normalizeUrl(str).replace(/\/assets\//, '').replace(/-[A-Z0-9]{8}/, '');
@@ -69,9 +74,19 @@ const hanamiEsbuild = (options: HanamiEsbuildPluginOptions = { ...defaults }): P
 
           const destinationUrl = calulateDestinationUrl(key);
           const sourceUrl = calulateSourceUrl(destinationUrl);
-          const subresourceIntegrity = calculateSubresourceIntegrity(options.sriAlgorithm, key);
 
-          assetsManifest[sourceUrl] = { "url": destinationUrl, "sri": subresourceIntegrity };
+          var asset: Asset = { url: destinationUrl };
+
+          if (options.sriAlgorithms.length > 0) {
+            asset.sri = [];
+
+            for (const algorithm of options.sriAlgorithms) {
+              const subresourceIntegrity = calculateSubresourceIntegrity(algorithm, key);
+              asset.sri.push(subresourceIntegrity);
+            }
+          }
+
+          assetsManifest[sourceUrl] = asset;
         }
 
         // Write assets manifest to the destination directory

--- a/test/hanami-esbuild.test.ts
+++ b/test/hanami-esbuild.test.ts
@@ -70,13 +70,16 @@ describe('hanamiEsbuild', () => {
     // Check if the manifest contains the correct file paths
     expect(manifest).toEqual({
       "admin/index.js": {
-        "url": "/assets/admin/index-YMWJCFAK.js"
+        "url": "/assets/admin/index-YMWJCFAK.js",
+        "sri": "sha256-Lc5EeWq0rkBO9qgHXBcGmoHWyChQmENK8wj1W39LcqM="
       },
       "index.js": {
-        "url": "/assets/index-A3EJVGR4.js"
+        "url": "/assets/index-A3EJVGR4.js",
+        "sri": "sha256-/lxoexmKjJgp4Fx1JnExzKN1/UKRcjBMmDkREEuF448="
       },
       "metrics/app.js": {
-        "url": "/assets/metrics/app-62A4ZWTV.js"
+        "url": "/assets/metrics/app-62A4ZWTV.js",
+        "sri": "sha256-fTQKAvMqOFXmH5p3ZrzBXvAQhHKGLKPfxxf8988y7fw="
       },
     });
   });


### PR DESCRIPTION
# Features

* Support [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)
* Generate a `sri` node in Manifest with an array of hashes (see code snippet below).
* The feature is activated by passing a `--sri` argument with a comma-separated list of algorithms (e.g. `--sri=sha256` or `--sri=sha384,sha512`).

```json
      "index.js": {
        "url": "/assets/index-A3EJVGR4.js",
        "sri": [
          "sha256-/lxoexmKjJgp4Fx1JnExzKN1/UKRcjBMmDkREEuF448=",
          "sha384-FxEUrhNW+v8maw4V1mMu8UrnJcbWUd5/9dWSJii1wGbCPrE+SQuqaSfLAtO5tk6k",
          "sha512-qnX1lVVY+KBRuXcXbaeJQNfT9Motew0OAQKwhkq0dalyBsM6Mzgmk3oD7pn08UVKsApLZZcMwDcZcTHvsV8jvg==",
        ]
      }
```